### PR TITLE
add support for nested testsuites/testsuite reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ to add unit and integration tests in a typical gradle based Java project you cou
 ## Screenshot
 ![LambdaCD with test reports](assets/pipeline-example.png "Pipeline with Unit tests and a failing Integration test")
 
+## JavaScript Example
+
+this example is based on _Jest_ (https://facebook.github.io/jest/) and _Jest Junit_ (https://github.com/palmerj3/jest-junit). 
+It should be easy to use different JavaScript testing tools as long as they are able to produce a junit report xml.
+
+Jest and Jest Junit need to be properly setup according to their documentation.
+
+```clojure
+(ns pipeline.steps
+  (:require
+    [clojure.java.io :as io]
+    [lambdacd-git.core :as core]
+    [lambdacd.steps.shell :as shell]
+    [lambdacd-junit.core :as junit4]))
+    
+(def javascript-jest-test-cmd "JEST_JUNIT_OUTPUT='./artifacts/junit.xml' jest --ci --testResultsProcessor='jest-junit'")
+
+(defn jest-test [args ctx]
+	(-> (shell/bash ctx (:cwd args) javascript-jest-test-cmd)
+		(junit4/junit4-reports args "/artifacts" "Jest Tests" [#"junit.xml"])))
+```
+		
 ## Related projects
 
 * [lambdacd](https://github.com/flosell/lambdacd): a library to define a continuous delivery pipeline in code

--- a/test-resources/JEST-report.xml
+++ b/test-resources/JEST-report.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite id="0" name="/Users/alphonse.bendt/Projects/wish-list-ui/wish-list-ui-server/src/test/js/i18n/polyglot.test.js" errors="0" package="/Users/alphonse.bendt/Projects/wish-list-ui/wish-list-ui-server/src/test/js/i18n/polyglot.test.js" hostname="localhost" tests="3" failures="0" time="0.845" timestamp="2018-04-26T14:50:12">
+        <properties>
+        </properties>
+        <testcase classname="Polyglot exploration test" name="can translate" time="0">
+        </testcase>
+        <testcase classname="Polyglot exploration test" name="can translate nested" time="0">
+        </testcase>
+        <testcase classname="Polyglot exploration test" name="can interpolate" time="0">
+        </testcase>
+        <system-out/>
+        <system-err/>
+    </testsuite>
+    <testsuite id="1" name="/Users/alphonse.bendt/Projects/wish-list-ui/wish-list-ui-server/src/test/js/compare/compare-panel.test.js" errors="0" package="/Users/alphonse.bendt/Projects/wish-list-ui/wish-list-ui-server/src/test/js/compare/compare-panel.test.js" hostname="localhost" tests="4" failures="0" time="0.478" timestamp="2018-04-26T14:50:13">
+        <properties>
+        </properties>
+        <testcase classname="ComparePanel" name="can add product" time="0">
+        </testcase>
+        <testcase classname="ComparePanel" name="can add product only once" time="0">
+        </testcase>
+        <testcase classname="ComparePanel" name="can add multiple product" time="0">
+        </testcase>
+        <testcase classname="ComparePanel" name="can remove products" time="0">
+        </testcase>
+        <system-out/>
+        <system-err/>
+    </testsuite>
+</testsuites>

--- a/test/lambdacd_junit/core_test.clj
+++ b/test/lambdacd_junit/core_test.clj
@@ -52,6 +52,19 @@
                :label   "Junit test results"})
    :status  :failure})
 
+(def jest-report
+  {:details '({:details ({:details ({:label "can translate{:time \"0\", :classname \"Polyglot exploration test\"}"}
+                                    {:label "can translate nested{:time \"0\", :classname \"Polyglot exploration test\"}"}
+                                    {:label "can interpolate{:time \"0\", :classname \"Polyglot exploration test\"}"}),
+                         :label "/Users/alphonse.bendt/Projects/wish-list-ui/wish-list-ui-server/src/test/js/i18n/polyglot.test.js{:timestamp \"2018-04-26T14:50:12\", :time \"0.845\", :failures \"0\", :tests \"3\", :hostname \"localhost\", :package \"/Users/alphonse.bendt/Projects/wish-list-ui/wish-list-ui-server/src/test/js/i18n/polyglot.test.js\", :errors \"0\", :id \"0\"}"}
+                         {:details ({:label "can add product{:time \"0\", :classname \"ComparePanel\"}"}
+                                     {:label "can add product only once{:time \"0\", :classname \"ComparePanel\"}"}
+                                     {:label "can add multiple product{:time \"0\", :classname \"ComparePanel\"}"}
+                                     {:label "can remove products{:time \"0\", :classname \"ComparePanel\"}"}),
+                          :label "/Users/alphonse.bendt/Projects/wish-list-ui/wish-list-ui-server/src/test/js/compare/compare-panel.test.js{:timestamp \"2018-04-26T14:50:13\", :time \"0.478\", :failures \"0\", :tests \"4\", :hostname \"localhost\", :package \"/Users/alphonse.bendt/Projects/wish-list-ui/wish-list-ui-server/src/test/js/compare/compare-panel.test.js\", :errors \"0\", :id \"1\"}"}),
+              :label "Jest rest results"}),
+   :status :failure})
+
 (deftest testcase-from-raw-test
   (testing "testcase-from-raw-test"
     (is (= first-testcase
@@ -69,3 +82,13 @@
           path "test-resources/"]
       (is (= report-out
              (junit4-reports shell-out args path "Junit test results" [#"TEST-.*"]))))))
+
+(deftest jest-reports-test
+  (testing "jest-reports-test"
+           (let [shell-out {:status :failure}
+                 args {:cwd "./"}
+                 path "test-resources/"]
+
+             (is (= jest-report
+                    (junit4-reports shell-out args path "Jest rest results" [#"JEST-.*"])))
+             )))


### PR DESCRIPTION
lambdacd-junit assumes that the generated XML report contains a top-level `testsuite` element.
We use the jest-junit-reporter to generate reports for our JS tests. Its reports contains a top-level `testsuites` element which contains nested `testsuite` elements.

we adapted lambdacd-junit to support this report format.

